### PR TITLE
Only take runtime defs as passed to client instantiation functions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,6 @@ jobs:
           check-latest: false
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm publish
+      - run: npm --workspace packages/lib publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25832,7 +25832,6 @@
       "license": "MIT",
       "dependencies": {
         "@composedb/client": "^0.6.0",
-        "@desci-labs/desci-codex-composedb": "^1.0.0",
         "dids": "^4.0.4",
         "gql-query-builder": "^3.8.0",
         "graphql": "^16.8.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/desci-codex-lib",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Codex interaction primitives",
   "license": "MIT",
   "author": "Edvard Hübinette",
@@ -19,13 +19,12 @@
     "vitest-github-actions-reporter": "^0.10.0"
   },
   "dependencies": {
-    "@desci-labs/desci-codex-composedb": "^1.0.0",
-    "uint8arrays": "^4.0.6",
+    "@composedb/client": "^0.6.0",
     "dids": "^4.0.4",
+    "gql-query-builder": "^3.8.0",
+    "graphql": "^16.8.0",
     "key-did-provider-ed25519": "^3.0.2",
     "key-did-resolver": "^3.0.0",
-    "@composedb/client": "^0.6.0",
-    "gql-query-builder": "^3.8.0",
-    "graphql": "^16.8.0"
+    "uint8arrays": "^4.0.6"
   }
 }

--- a/packages/lib/src/clients.ts
+++ b/packages/lib/src/clients.ts
@@ -7,7 +7,7 @@ import {
   CeramicClient,
   type CeramicClientConfig,
 } from "@ceramicnetwork/http-client";
-import { definition } from "@desci-labs/desci-codex-composedb/src/__generated__/definition.js";
+import type { Optional } from "./types.js";
 
 const DEFAULT_LOCAL_CERAMIC = "http://localhost:7007";
 
@@ -35,8 +35,10 @@ export const newCeramicClient = (
   return new CeramicClient(endpoint ?? DEFAULT_LOCAL_CERAMIC, config);
 };
 
-export const newComposeClient = (params?: Partial<ComposeClientParams>) => {
-  if (!params?.ceramic) {
+export const newComposeClient = (
+  params: Optional<ComposeClientParams, "ceramic">,
+) => {
+  if (!params.ceramic) {
     console.log(
       "[codex] ceramic client not provided; defaulting to",
       DEFAULT_LOCAL_CERAMIC,
@@ -45,8 +47,7 @@ export const newComposeClient = (params?: Partial<ComposeClientParams>) => {
 
   return new ComposeClient({
     ceramic: DEFAULT_LOCAL_CERAMIC,
-    definition,
-    // Let passed config overwrite, if present
+    // Let passed config overwrite ceramic, if present
     ...params,
   });
 };

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -342,3 +342,8 @@ export type UnionKeys<T> = T extends unknown ? keyof T : never;
 export type DistributiveOmit<T, K extends UnionKeys<T>> = T extends unknown
   ? Omit<T, Extract<keyof T, K>>
   : never;
+
+/**
+ * Make one key optional in a record type
+ */
+export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;


### PR DESCRIPTION
Long story short, figuring out which composeDB runtime definitions to use is non-trivial and can't really be done automatically from the lib. The reason for this is that they will change on every deploy, so the ones included will likely not work for someone else if they deploy to their local dev cluster, because the streamID's of the models will have changed.

When there is a public deployment, the lib can default to the corresponding runtime definition. Until then, when instantiating a composeDB client with the codex lib, one will have to pass the runtime definition object.