### PR TITLE
Add default http/ssl port if not included in flight endpoint

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/desci-codex-lib",
-  "version": "2.0.0-rc8",
+  "version": "2.0.0-rc9",
   "description": "Codex interaction primitives",
   "license": "MIT",
   "author": "Edvard Hübinette",

--- a/packages/lib/src/c1/flightclient.ts
+++ b/packages/lib/src/c1/flightclient.ts
@@ -7,7 +7,7 @@ export const newFlightSqlClient = (flightUrl: string) => {
 
   return createFlightSqlClient({
     host: url.hostname,
-    port: parseInt(url.port),
+    port: parseInt(url.port) || (url.protocol === "https:" ? 443 : 80),
     tls: url.protocol === "https:",
     headers: [],
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.0.0-rc9

* **Bug Fixes**
  * Enhanced connection reliability by improving port handling. The system now automatically applies appropriate defaults based on your connection protocol when a specific port isn't explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->